### PR TITLE
feat: 修复在 ts 中引入 Ruler 时的类型报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "dist/index.esm.js",
   "exports": {
     "import": "./dist/index.esm.js",
-    "require": "./dist/index.cjs"
+    "require": "./dist/index.cjs",
+    "types": "./types/index.d.ts"
   },
   "types": "types/index.d.ts",
   "files": [


### PR DESCRIPTION
在 vue sfc  的 ts script 中引入 Ruler 时会报错:

<img width="1097" alt="image" src="https://github.com/user-attachments/assets/a299cbfa-b4ec-4a54-8c65-3c1d59c3ae15">

编译时也会报错:
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/01949a17-112f-4485-8f0d-98517b945109">

修改后，类型报错消失。麻烦合并一下，重新发个包。