### PR TITLE
fix: 修复事件设置的bug

### DIFF
--- a/src/Ruler.ts
+++ b/src/Ruler.ts
@@ -93,6 +93,7 @@ export class Ruler {
     }
     this.config = config || { enabled: true, theme: 'light' }
     this.forceRender = this.forceRender.bind(this)
+    this.resize = this.resize.bind(this)
     this.enabled = this.config.enabled
   }
 
@@ -137,13 +138,13 @@ export class Ruler {
   public set enabled(value: boolean) {
     this.config.enabled = value
     if (value) {
-      this.app.tree.on(LayoutEvent.AFTER, this.forceRender.bind(this))
-      this.app.tree.on(ResizeEvent.RESIZE, this.resize.bind(this))
+      this.app.tree.on(LayoutEvent.AFTER, this.forceRender)
+      this.app.tree.on(ResizeEvent.RESIZE, this.resize)
       this.app.editor?.on(EditorEvent.SELECT,this.forceRender)
       this.resize()
     } else {
-      this.app.tree.off(RenderEvent.AFTER, this.forceRender.bind(this))
-      this.app.tree.off(ResizeEvent.RESIZE, this.resize.bind(this))
+      this.app.tree.off(LayoutEvent.AFTER, this.forceRender)
+      this.app.tree.off(ResizeEvent.RESIZE, this.resize)
       this.app.editor?.off(EditorEvent.SELECT, this.forceRender)
       this.rulerLeafer.forceRender()
     }


### PR DESCRIPTION
修复事件绑定与解绑的bug。

1. 绑定的是 LayoutEvent.AFTER，解绑的是 RenderEvent.AFTER
2. 绑定时使用 `Function.prototype.bind` 函数，将产生新的函数，如果绑定和解绑都使用该函数产生新的回调函数，因为绑定与解绑的函数不同，不能实现解绑的效果